### PR TITLE
Add git clone stage and run ssh server as non-root user

### DIFF
--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -27,10 +27,10 @@ services:
      container_name: job-dispatcher-container
      build:
        context: .
-       dockerfile: spark-server.Dockerfile
-       target: spark-master
        ssh:
         - default
+       dockerfile: spark-server.Dockerfile
+       target: spark-master
      networks:
        - app-network
      ports:
@@ -49,6 +49,7 @@ services:
   spark-worker:
      container_name: spark-worker-container
      build:
+        context: .
         dockerfile: spark-server.Dockerfile 
         target: spark-worker
      depends_on: 

--- a/server/docker/spark-entrypoint.sh
+++ b/server/docker/spark-entrypoint.sh
@@ -18,7 +18,7 @@ if [ "$SPARK_TYPE" == "master" ]; then
 
 	start_job_dispatcher.sh
 elif [ "$SPARK_TYPE" == "worker" ]; then
-	service ssh start
+	/usr/sbin/sshd -f ~/ssh/sshd_config && \
 	start-worker.sh spark://job-dispatcher-container:7077
 fi
 

--- a/server/docker/sshd_config
+++ b/server/docker/sshd_config
@@ -101,7 +101,7 @@ MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@op
 
 # only use host keys with secure HostKeyAlgorithms
 # omit the ECDSA key since it is only used in conjunction with the NIST P-curves
-HostKey /etc/ssh/ssh_host_ed25519_key
+HostKey /home/octopus/ssh/ssh_host_ed25519_key
 
 # short moduli should be deactivated before enabling the use of diffie-hellman-group-exchange-sha256
 #   see this link for more details: https://github.com/k4yt3x/sshd_config#deactivating-short-diffie-hellman-moduli
@@ -155,3 +155,5 @@ TCPKeepAlive no
 
 # disable reverse DNS lookups
 UseDNS no
+
+AuthorizedKeysFile  /home/octopus/.ssh/authorized_keys


### PR DESCRIPTION
- `docker-compose.yml`: attach ssh-agent for spark-master builds
- `spark-entrypoint.sh`: start ssh daemon as non-root user
- `sshd_config`: use non-root user host key and add reference to `known_hosts` file
- `spark-server.Dockerfile`: add separate stage for `git clone` and copy only `server` dir from it; small adjustments and layers optimization